### PR TITLE
Fixed .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/vendor
-composer.phar
 composer.lock
-.DS_Store
+phpunit.xml
+vendor


### PR DESCRIPTION
Basically no-one actually uses composer.phar per project these days, and if they do, then can ignore it in their system ignore file. As for .DS_Store, that 100% belongs in the system ignore file, not the project one.
